### PR TITLE
Autodetect sound hardware to support more than the first device.

### DIFF
--- a/pulseaudio/config.json
+++ b/pulseaudio/config.json
@@ -12,9 +12,6 @@
   "image": "torvitas/{arch}-hassio-pulseaudio",
   "devices":["/dev/snd:/dev/snd:rwm"],
   "host_dbus" : "true",
-  "environment": {
-      "ALSA_OUTPUT": "0,0"
-  },
   "ports": {
     "4713/tcp": 4713
   }

--- a/pulseaudio/default.pa
+++ b/pulseaudio/default.pa
@@ -1,3 +1,8 @@
-load-module module-alsa-sink device=hw:0,0
+.ifexists module-udev-detect.so
+load-module module-udev-detect
+.else
+### Use the static hardware detection module (for systems that lack udev/hal support)
+load-module module-detect
+.endif
 load-module module-native-protocol-unix
 load-module module-native-protocol-tcp auth-ip-acl=127.0.0.0/8;172.0.0.0/8 auth-anonymous=1

--- a/pulseaudio/default.pa
+++ b/pulseaudio/default.pa
@@ -1,8 +1,3 @@
-.ifexists module-udev-detect.so
-load-module module-udev-detect
-.else
-### Use the static hardware detection module (for systems that lack udev/hal support)
 load-module module-detect
-.endif
 load-module module-native-protocol-unix
 load-module module-native-protocol-tcp auth-ip-acl=127.0.0.0/8;172.0.0.0/8 auth-anonymous=1


### PR DESCRIPTION
In all honesty, I haven't tested this PR because I can't get this addon building on my device for some reason. However, this config snippet worked to detect all devices on my original Hasbian installation, so I imagine it will work here. Fairly new to Hass.io, so if you have thoughts on how to test this other than pushing the image to Docker Hub and letting me try it locally and report back, I'm open to them. But since I can't get it building locally on the Pi, I'm not sure what to do.